### PR TITLE
race condition in ast_module_info->self caused segv

### DIFF
--- a/chan_capi_ami.c
+++ b/chan_capi_ami.c
@@ -95,46 +95,48 @@ static char mandescr_capicommand[] =
 "    *Channel: <channame>\n"
 "    *Capicommand: <capicommand>\n";
 
+#ifdef CC_AST_HAS_VERSION_11_0
+void pbx_capi_ami_register(struct ast_module *myself)
+{
+
+	capiChatListRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATLIST,
+		EVENT_FLAG_REPORTING,
+		pbx_capi_ami_capichat_list,
+		module,
+		"List participants in a conference",
+		mandescr_capichatlist) == 0;
+
+	capiChatMuteRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATMUTE,
+		EVENT_FLAG_CALL,
+		pbx_capi_ami_capichat_mute,
+		module,
+		"Mute a conference user",
+		mandescr_capichatmute) == 0;
+
+	capiChatUnmuteRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATUNMUTE,
+		EVENT_FLAG_CALL,
+		pbx_capi_ami_capichat_unmute,
+		module,
+		"Unmute a conference user",
+		mandescr_capichatunmute) == 0;
+
+	capiChatRemoveRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATREMOVE,
+		EVENT_FLAG_CALL,
+		pbx_capi_ami_capichat_remove,
+		module,
+		"Remove a conference user",
+		mandescr_capichatremove) == 0;
+
+	capiCommandRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CAPICOMMAND,
+		EVENT_FLAG_CALL,
+		pbx_capi_ami_capicommand,
+		module,
+		"Exec capicommand",
+		mandescr_capicommand) == 0;
+#else
 void pbx_capi_ami_register(void)
 {
-	#ifdef CC_AST_HAS_VERSION_11_0
-	struct ast_module* module = ast_module_info->self;
-	
-	capiChatListRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATLIST,
-		EVENT_FLAG_REPORTING,
-		pbx_capi_ami_capichat_list,
-		module,
-		"List participants in a conference",
-		mandescr_capichatlist) == 0;
 
-	capiChatMuteRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATMUTE,
-		EVENT_FLAG_CALL,
-		pbx_capi_ami_capichat_mute,
-		module,
-		"Mute a conference user",
-		mandescr_capichatmute) == 0;
-
-	capiChatUnmuteRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATUNMUTE,
-		EVENT_FLAG_CALL,
-		pbx_capi_ami_capichat_unmute,
-		module,
-		"Unmute a conference user",
-		mandescr_capichatunmute) == 0;
-
-	capiChatRemoveRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATREMOVE,
-		EVENT_FLAG_CALL,
-		pbx_capi_ami_capichat_remove,
-		module,
-		"Remove a conference user",
-		mandescr_capichatremove) == 0;
-
-	capiCommandRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CAPICOMMAND,
-		EVENT_FLAG_CALL,
-		pbx_capi_ami_capicommand,
-		module,
-		"Exec capicommand",
-		mandescr_capicommand) == 0;
-	#else
 	capiChatListRegistered = ast_manager_register2(CC_AMI_ACTION_NAME_CHATLIST,
 		EVENT_FLAG_REPORTING,
 		pbx_capi_ami_capichat_list,
@@ -164,7 +166,7 @@ void pbx_capi_ami_register(void)
 		pbx_capi_ami_capicommand,
 		"Exec capicommand",
 		mandescr_capicommand) == 0;
-	#endif
+#endif
 }
 
 void pbx_capi_ami_unregister(void)


### PR DESCRIPTION
Please pull this commit - there has been a race condition. ast_module_info was not synchronized so access to it could (and dit) cause segv.

There's no need to use ast_module_info->self as the module object is available in chan_capi.c ...
